### PR TITLE
Remove .deb version of Alacritty

### DIFF
--- a/tasks/apps.yml
+++ b/tasks/apps.yml
@@ -1,9 +1,16 @@
 ---
 
-- name: Download Alacritty
+- name: Download Alacritty from apt
   apt:
-    deb: https://github.com/barnumbirr/alacritty-debian/releases/download/v0.10.1-1/alacritty_0.10.1-1_amd64_bullseye.deb
+    name: alacritty
   become: true
+  when: not (ansible_facts['distribution'] == 'Ubuntu') and not (ansible_facts['distribution_release'] == 'jammy')
+
+- name: Download Alacritty .deb
+  apt:
+      deb: https://github.com/barnumbirr/alacritty-debian/releases/download/v0.10.1-1/alacritty_0.10.1-1_amd64_bullseye.deb
+  become: true
+  when: (ansible_facts['distribution'] == 'Ubuntu') and (ansible_facts['distribution_release'] == 'jammy')
 
 - name: Move config file
   copy:


### PR DESCRIPTION
Before merging, this should probably be tested on Ubuntu 22.04 - I think doing `sudo apt install Alacritty` will just install the snap, which is why I made this change in the first place? Running it in Pop-OS installs the .deb already. Perhaps I can have something here that runs `apt install` on pop-os or ubuntu < 22.04, and then on Ubuntu Jammy, use the .deb manually?

In the future, I'd still want to build from source though. 